### PR TITLE
update to keep up with shinken graphite module.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Shinken module for enabling graphs from Graphite into WebUI
 Installation
 ------------
 * `$ shinken install ui-graphite`
-* **clone** the this git repo and copy the **module.py** file to the **/var/lib/shinken/modules/ui-graphite**dir.(assuming you install shinken lib in default dir)
+* **clone** the this git repo and copy the **module.py** file to the **/var/lib/shinken/modules/ui-graphite** dir.(assuming you install shinken lib in default dir)
 
 Bugfix
 ------------

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Installation
 
 Bugfix
 ------------
-* fix the incompatible metric name process with the module graphite of shinken
+* fix the incompatible metric name derive process with the module graphite of shinken

--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ Installation
 
 Bugfix
 ------------
-* fix the incompatible metric name derive process with the module graphite of shinken
+* fix the incompatible **metric name** derive process with the module graphite of shinken
+* fix the incompatible **_GRAPHITE_PRE** and **_GRAPHITE_POST** process with the module graphite of shinken

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Shinken module for enabling graphs from Graphite into WebUI
 Installation
 ------------
 * `$ shinken install ui-graphite`
-* clone the this git repo and copy the module.py file to the **/var/lib/shinken/modules/ui-graphite**(assuming you install shinken lib in default dir)
+* **clone** the this git repo and copy the **module.py** file to the **/var/lib/shinken/modules/ui-graphite**dir.(assuming you install shinken lib in default dir)
 
 Bugfix
 ------------

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Shinken module for enabling graphs from Graphite into WebUI
 
 Installation
 ------------
-`$ shinken install ui-graphite`
+* `$ shinken install ui-graphite`
+* clone the this git repo and copy the module.py file to the **/var/lib/shinken/modules/ui-graphite**(assuming you install shinken lib in default dir)
 
 Bugfix
 ------------

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Shinken module for enabling graphs from Graphite into WebUI
 Installation
 ------------
 `$ shinken install ui-graphite`
+
+Bugfix
+------------
+* fix the incompatible metric name process with the module graphite of shinken

--- a/module/module.py
+++ b/module/module.py
@@ -153,12 +153,12 @@ class Graphite_Webui(BaseModule):
             data_source = ".%s" % self.graphite_data_source
         if t == 'host':
             if "_GRAPHITE_PRE" in elt.customs:
-                graphite_pre = "%s." % self.illegal_char.sub("_", elt.customs["_GRAPHITE_PRE"])
+                graphite_pre = "%s." % elt.customs["_GRAPHITE_PRE"]
         elif t == 'service':
             if "_GRAPHITE_PRE" in elt.host.customs:
-                graphite_pre = "%s." % self.illegal_char.sub("_", elt.host.customs["_GRAPHITE_PRE"])
+                graphite_pre = "%s." % elt.host.customs["_GRAPHITE_PRE"]
             if "_GRAPHITE_POST" in elt.customs:
-                graphite_post = ".%s" % self.illegal_char.sub("_", elt.customs["_GRAPHITE_POST"])
+                graphite_post = ".%s" % elt.customs["_GRAPHITE_POST"]
 
         # Format the start & end time (and not only the date)
         d = datetime.fromtimestamp(graphstart)

--- a/module/module.py
+++ b/module/module.py
@@ -102,7 +102,7 @@ class Graphite_Webui(BaseModule):
                 pass
 
             name = self.illegal_char.sub('_', e.name)
-            name = self.multival.sub(r'.*', name)
+            name = self.multival.sub(r'.\1', name)
 
             # get metric value and its thresholds values if they exist
             name_value = {name: (e.value, e.uom)}


### PR DESCRIPTION
change the sub regex of "self.multival.sub(r'.*', name)" to  self.multival.sub(r'.\1', name) to keep up with shinken graphite module.py about how to parse the perfdata. 
or otherwise, it will break with perfdata name "demo_123" with the wrong replaced one "demo" instead the correct one "demo.123", and finally result in "no data" in WebUI when graphite UI request the url.