### PR TITLE
add debugging for template path

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -180,7 +180,7 @@ class Graphite_Webui(BaseModule):
             if not os.path.isfile(thefile):
                 thefile = os.path.join(self.templates_path, filename) 
 
-        logger.debug("[ui-graphite] template=%s" % str(thefile))
+        logger.debug("[ui-graphite] template=%s", thefile)
         if os.path.isfile(thefile):
             template_html = ''
             with open(thefile, 'r') as template_file:


### PR DESCRIPTION
without a debug msg the change in behaviour of 1.4.x and 2.0.3 in finding templates (1.4.x: <path> is enough, 2.0.3: <path>/detail) wouldn't have been found.
Thanks,
  Hermann
