### PR TITLE
fix for alternate graphit root urls in templates

### DIFF
--- a/module/graphite_utils.py
+++ b/module/graphite_utils.py
@@ -144,7 +144,7 @@ class GraphiteURL(object):
         self._start = ''
         self._end = ''
         if server.endswith('/'):
-            server=server[:-1]
+            server = server[:-1]
         self.server = server
         self.start = start
         self.end = end
@@ -214,7 +214,10 @@ class GraphiteURL(object):
         server = '{0.scheme}://{0.hostname}'.format(parts)
         if parts.port:
             server += ':%d' % parts.port
-        server += '/'
+        path = parts.path.split('/')
+        # strip out the final component (should be render or composer) since the args list is
+        # separated from the path by a '/?' this is actually the last two elements that need to be dropped
+        server += '/'.join(path[:-2])
 
         obj = cls(style=style, server=server)
         # style

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 import logging
 
-logging.basicConfig(level=logging.ERROR)
+logging.basicConfig(level=logging.INFO)
 
 FILE_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = os.path.abspath(os.path.join(FILE_PATH, '../'))
@@ -419,7 +419,7 @@ class TestGraphFactory(unittest.TestCase):
         self.config = ShinkenModuleConfig()
         self.config.set_value('templates_path', os.path.join(ROOT_PATH, 'templates', 'graphite'))
         self.config.set_value('hostcheck', '__HOST__')
-        self.config.set_value('uri', 'http://example.com/')
+        self.config.set_value('uri', 'http://example.com/graphite/')
         self.config.set_value('tz', None)
         self.config.set_value('lineMode', None)
         self.config.set_value('color_warning', None)
@@ -450,12 +450,12 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 2)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/composer/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Response Time on testhost&yMin=0&target=legendValue(alias(testhost.__HOST__.rta,"Response Time"),"last")',
-            'img_src': 'http://example.com/render/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Response Time on testhost&yMin=0&target=legendValue(alias(testhost.__HOST__.rta,"Response Time"),"last")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Response Time on testhost&yMin=0&target=legendValue(alias(testhost.__HOST__.rta,"Response Time"),"last")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Response Time on testhost&yMin=0&target=legendValue(alias(testhost.__HOST__.rta,"Response Time"),"last")'
         })
         self.assertEqual(uris[1], {
-            'link': 'http://example.com/composer/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Packet Loss Percentage on testhost&yMin=0&yMax=100&target=legendValue(alias(testhost.__HOST__.pl,"Packet loss percentage"),"last")',
-            'img_src': 'http://example.com/render/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Packet Loss Percentage on testhost&yMin=0&yMax=100&target=legendValue(alias(testhost.__HOST__.pl,"Packet loss percentage"),"last")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Packet Loss Percentage on testhost&yMin=0&yMax=100&target=legendValue(alias(testhost.__HOST__.pl,"Packet loss percentage"),"last")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=4&from=17:00_19691231&until=07:53_19700102&title=Packet Loss Percentage on testhost&yMin=0&yMax=100&target=legendValue(alias(testhost.__HOST__.pl,"Packet loss percentage"),"last")'
         })
 
     def test_service_url_template(self):
@@ -473,8 +473,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': '''http://example.com/composer/?width=586&height=308&fontSize=8&fgcolor=000000&bgcolor=FFFFFF&areaMode=stacked&yMax=100&target=alias(legendValue(testhost.check_cpu._user_,"last"),"User")&target=alias(legendValue(testhost.check_cpu._sys_,"last"),"Sys")&target=alias(legendValue(testhost.check_cpu._softirq_,"last"),"SoftIRQ")&target=alias(legendValue(testhost.check_cpu._nice_,"last"),"Nice")&target=alias(legendValue(testhost.check_cpu._irq_,"last"),"IRQ")&target=alias(legendValue(testhost.check_cpu._iowait_,"last"),"I/O Wait")&target=alias(legendValue(testhost.check_cpu._idle_,"last"),"Idle")''',
-            'img_src': '''http://example.com/render/?width=586&height=308&fontSize=8&fgcolor=000000&bgcolor=FFFFFF&areaMode=stacked&yMax=100&target=alias(legendValue(testhost.check_cpu._user_,"last"),"User")&target=alias(legendValue(testhost.check_cpu._sys_,"last"),"Sys")&target=alias(legendValue(testhost.check_cpu._softirq_,"last"),"SoftIRQ")&target=alias(legendValue(testhost.check_cpu._nice_,"last"),"Nice")&target=alias(legendValue(testhost.check_cpu._irq_,"last"),"IRQ")&target=alias(legendValue(testhost.check_cpu._iowait_,"last"),"I/O Wait")&target=alias(legendValue(testhost.check_cpu._idle_,"last"),"Idle")'''
+            'link': '''http://example.com/graphite/composer/?width=586&height=308&fontSize=8&fgcolor=000000&bgcolor=FFFFFF&areaMode=stacked&yMax=100&target=alias(legendValue(testhost.check_cpu._user_,"last"),"User")&target=alias(legendValue(testhost.check_cpu._sys_,"last"),"Sys")&target=alias(legendValue(testhost.check_cpu._softirq_,"last"),"SoftIRQ")&target=alias(legendValue(testhost.check_cpu._nice_,"last"),"Nice")&target=alias(legendValue(testhost.check_cpu._irq_,"last"),"IRQ")&target=alias(legendValue(testhost.check_cpu._iowait_,"last"),"I/O Wait")&target=alias(legendValue(testhost.check_cpu._idle_,"last"),"Idle")''',
+            'img_src': '''http://example.com/graphite/render/?width=586&height=308&fontSize=8&fgcolor=000000&bgcolor=FFFFFF&areaMode=stacked&yMax=100&target=alias(legendValue(testhost.check_cpu._user_,"last"),"User")&target=alias(legendValue(testhost.check_cpu._sys_,"last"),"Sys")&target=alias(legendValue(testhost.check_cpu._softirq_,"last"),"SoftIRQ")&target=alias(legendValue(testhost.check_cpu._nice_,"last"),"Nice")&target=alias(legendValue(testhost.check_cpu._irq_,"last"),"IRQ")&target=alias(legendValue(testhost.check_cpu._iowait_,"last"),"I/O Wait")&target=alias(legendValue(testhost.check_cpu._idle_,"last"),"Idle")'''
         })
 
     def test_service_generate(self):
@@ -491,8 +491,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/composer/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")',
-            'img_src': 'http://example.com/render/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")'
         })
 
     def test_service_generate_graphite_path_mods(self):
@@ -514,8 +514,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/composer/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")',
-            'img_src': 'http://example.com/render/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=17:00_19691231&until=07:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")'
         })
 
 


### PR DESCRIPTION
This should correct the reported issue with alternate webroots for graphite, lets try creating it against the correct branch this time
