### PR TITLE
Zero valued attributes in perfdata not passed on to graph url  construction.

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -163,7 +163,7 @@ class Graphite_Webui(BaseModule):
 
             # Get or ignore extra values depending upon module configuration
             for s in ('warning', 'critical', 'min', 'max'):
-                if getattr(e, s) and getattr(self, 'use_%s' % s):
+                if getattr(e, s) is not None  and getattr(self, 'use_%s' % s):
                     metric[s] = getattr(e, s)
 
             result.append(metric)

--- a/module/util.py
+++ b/module/util.py
@@ -187,7 +187,6 @@ class GraphFactory(object):
             graphite_metric = GraphiteMetric(self.prefix, self.hostname,
                                              self.cfg.graphite_data_source,
                                              self.servicename, metric['name'], self.postfix)
-            graph.add_target(graphite_metric, alias=metric['name'], color='green')
 
             #TODO - Shinken appears to store these in graphite, rather than using the current value as a constant line,
             #TODO - use the approppriate time series from graphite
@@ -198,6 +197,8 @@ class GraphFactory(object):
                 if t in metric:
                     n = 'color_%s' % t
                     graph.add_target('constantLine(%s)' % metric[t], alias=t.title(), color=getattr(self.cfg, n))
+
+            graph.add_target(graphite_metric, alias=metric['name'], color='green')
 
             v = dict(
                 link=graph.url('composer'),

--- a/module/util.py
+++ b/module/util.py
@@ -197,7 +197,7 @@ class GraphFactory(object):
             for t in ('warning', 'critical', 'min', 'max'):
                 if t in metric:
                     n = 'color_%s' % t
-                    graph.add_target('constantLine(%d)' % metric[t], alias=t.title(), color=getattr(self.cfg, n))
+                    graph.add_target('constantLine(%s)' % metric[t], alias=t.title(), color=getattr(self.cfg, n))
 
             v = dict(
                 link=graph.url('composer'),

--- a/tests/test.py
+++ b/tests/test.py
@@ -18,6 +18,7 @@ from module.graphite_utils import GraphStyle, GraphiteTarget, GraphiteURL, Graph
     GraphiteRewriteRule, GraphiteFunction, GraphiteString
 from fake_shinken import Host, CheckCommand, Service, ShinkenModuleConfig
 
+os.environ["TZ"] = "UTC"
 
 class TestGraphiteTarget(unittest.TestCase):
     def test_empty(self):

--- a/tests/test.py
+++ b/tests/test.py
@@ -552,8 +552,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")',
-            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")'
         })
 
     def test_service_generate_graphite_path_mods(self):
@@ -575,8 +575,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")',
-            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")'
         })
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -430,7 +430,7 @@ class TestGraphFactory(unittest.TestCase):
         self.config.set_value('lineMode', None)
         self.config.set_value('graphite_data_source', '')
         self.config.set_value('get_metric_and_value', lambda x, y: [
-            {'name': 'testMetric', 'uom': 'msec', 'min': 0, 'critical': 500, 'warning': 600}])
+            {'name': 'testMetric', 'uom': 'msec', 'min': 0, 'max': 3.7, 'critical': 500, 'warning': 600}])
         self.styles = {
             'default': GraphStyle(),
             'detail': GraphStyle(),
@@ -492,8 +492,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")',
-            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")'
         })
 
     def test_service_generate_graphite_path_mods(self):
@@ -515,8 +515,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")',
-            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")'
         })
 
 


### PR DESCRIPTION
The `get_metric_and_value` method uses the boolean-is-ness of `getattr(e, s)` but should use `getattr(e, s) is not None` as the proper test for including an attribute like warning, critical, min or max.
