### PR TITLE
fix missing 'end' and 'start' in context for custom graphite template…

### DIFF
--- a/module/util.py
+++ b/module/util.py
@@ -259,7 +259,7 @@ class GraphFactory(object):
                 GraphiteMetric.join(self.prefix, self.hostname, self.cfg.graphite_data_source)),
             service=GraphiteMetric.normalize(GraphiteMetric.join(self.servicename, self.postfix)),
             end=graph_end,
-            start=self.graph_start,
+            start=graph_start,
         )
 
 

--- a/module/util.py
+++ b/module/util.py
@@ -257,7 +257,9 @@ class GraphFactory(object):
             uri=self.cfg.uri,
             host=GraphiteMetric.normalize(
                 GraphiteMetric.join(self.prefix, self.hostname, self.cfg.graphite_data_source)),
-            service=GraphiteMetric.normalize(GraphiteMetric.join(self.servicename, self.postfix))
+            service=GraphiteMetric.normalize(GraphiteMetric.join(self.servicename, self.postfix)),
+            end=graph_end,
+            start=self.graph_start,
         )
 
 


### PR DESCRIPTION
this PR allow to write a custom template graph which change by selecting a time range in the graph page.

I am using linux-snmp to get my metrics, and it seem that some custom graphs don't change by selecting a time range in the webui. 

neither 1 day, 1 week or others change the graph. it seem the template I have in /var/lib/shinken/share/templates/graphite don't include the `from=` or `until=` required by graphite. but it seem that these values are not available in the template since only host, service and uri is inserted in the context.

I just added end and start to this template and it seem to work with a modified templates in /var/lib/shinken/share/templates/graphite (added `&from=${start}&until=${end}` at the end of each templates)
